### PR TITLE
update release procedure

### DIFF
--- a/release
+++ b/release
@@ -23,10 +23,8 @@ mvn clean install
 mvn versions:set -DnewVersion=${REPORTS_VERSION} -DgenerateBackupPoms=false
 git commit -a -m "Pinery Reports ${REPORTS_VERSION} release"
 git tag v${REPORTS_VERSION}
-mvn deploy
 mvn versions:set -DnewVersion=${REPORTS_VERSION_NEXT} -DgenerateBackupPoms=false
 git commit -a -m "prepare for next development iteration"
-git push origin v${REPORTS_VERSION} --follow-tags
 git push -u origin v${REPORTS_VERSION_NEXT}_pr
 set +x
 


### PR DESCRIPTION
Don't deploy or push release tags before the release PR is approved. (These steps have been moved to the [wiki page](https://wiki.oicr.on.ca/display/GSI/Deploying+a+new+version+of+Pinery+Reports) for releasing and deploying Pinery Reports)