### PR TITLE
Allow reports to interact with Guanyin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ mvn clean install
 ## Generate
 
 ```
-java -jar pinery-reports-<version>-jar-with-dependencies.jar -s <pinery-url> -r <report> -f <format> -o <filename> [report-specific-options]
+java -jar pinery-reports-<version>-jar-with-dependencies.jar -s <pinery-url> -r <report> -f <format> -g <guanyin-url> -o <filename> [report-specific-options]
 ```
 
 ## Options
@@ -22,8 +22,9 @@ java -jar pinery-reports-<version>-jar-with-dependencies.jar -s <pinery-url> -r 
 | Option | Required | Description | Example |
 |--------|----------|-------------|---------|
 | -s <pinery-url> | YES | Source Pinery URL | -s http://localhost:8080/pinery-miso |
-| -r <report-name> | YES | Report to generate See Reports below | -r stock |
+| -r <report-name> | YES | Report to generate. See Reports below | -r stock |
 | -f <format> | no | Output format. Can be csv or pdf. Some formats may not be available for all reports. Default varies by report. See Reports below | -f pdf |
+| -g <guanyin-url> | no | Guanyin URL. If provided, when a report is run it will make sure it is registered with Guanyin, and will create an output file that can be sent to Guanyin to record that the report was run | -g http://guanyin.url:3000 |
 | -o <filename> | no | Output file. Defaults to "report.csv" or "report.pdf" in current working directory | -o ~/reports/PCSI-stocks-2017-06.pdf |
 
 ## Reports
@@ -50,7 +51,10 @@ Generating the reports can be done by running a Docker container with the report
     * to save the file back to the host machine, use the `-v` option to link any host machine directory to the `/output`
 	  directory in the Docker container.
     * doing so will cause the file to have the same permissions as the user who ran the Docker container
-  * to use the host's network (to access an intranet-accessible Pinery, for instance), run the container with the option `--network host`.
+  * to use the host's network (to access an intranet-accessible Pinery or [Guanyin](https://github.com/oicr-gsi/guanyin), for instance),
+      run the container with the option `--network host`.
+  * if the `GUANYIN_URL` option is provided, the report will register itself with Guanyin if no necessary, and will write a file (in
+      the same directory as the report is written to) containing JSON that can be used to create a Guanyin report record. 
 
 ```
 docker run -it --rm \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,12 +19,19 @@ then
   exit 1
 fi
 
+GUANYIN_OPTION=''
+if [ ! -z "$GUANYIN_URL" ]
+then
+  GUANYIN_OPTION="-g $GUANYIN_URL"
+fi
+
 FILE_NAME="${FILE_NAME:-output.csv}"
 
 echo Pinery: $PINERY_URL
 echo Report: $REPORT_NAME
 echo File: $FILE_NAME
+echo Guanyin option: $GUANYIN_OPTION
 
 echo Report-specific parameters: $@
 cd /app
-exec java -jar $JAR_FILE -s "$PINERY_URL" -r "$REPORT_NAME" -o /output/"$FILE_NAME" $@
+exec java -jar $JAR_FILE -s "$PINERY_URL" -r "$REPORT_NAME" "$GUANYIN_OPTION" -o /output/"$FILE_NAME" $@

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,11 @@
       <version>1.4</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.8</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
@@ -149,6 +154,7 @@
           <archive>
             <manifest>
               <mainClass>ca.on.oicr.pineryreports.Main</mainClass>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             </manifest>
           </archive>
         </configuration>

--- a/src/main/java/ca/on/oicr/pineryreports/reports/Report.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/Report.java
@@ -3,6 +3,7 @@ package ca.on.oicr.pineryreports.reports;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -48,6 +49,11 @@ public interface Report {
   public String getTitle();
   
   /**
+   * Returns the category of this report.
+   */
+  public String getCategory();
+
+  /**
    * Collect data from Pinery, generate the report according to the options, and write it to file. Must not be called
    * before {@link #processOptions(CommandLine)}
    * 
@@ -56,5 +62,13 @@ public interface Report {
    * @param outFile output file
    */
   public void generate(PineryClient pinery, ReportFormat format, File outFile) throws HttpResponseException, IOException;
+
+  public void registerReportWithGuanyin(String guanyinUrl) throws HttpResponseException, IOException;
   
+  public void writeGuanyinReportRecordParameters(String guanyinUrl, File outputFile) throws IOException;
+
+  public Map<String, String> getOptionsUsed();
+
+  public void recordOptionsUsed(CommandLine cmd);
+
 }

--- a/src/main/java/ca/on/oicr/pineryreports/reports/TableReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/TableReport.java
@@ -3,9 +3,31 @@ package ca.on.oicr.pineryreports.reports;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Sets;
 import com.itextpdf.io.font.FontConstants;
 import com.itextpdf.kernel.events.IEventHandler;
@@ -23,9 +45,11 @@ import com.itextpdf.layout.property.TextAlignment;
 
 import ca.on.oicr.pinery.client.HttpResponseException;
 import ca.on.oicr.pinery.client.PineryClient;
+import ca.on.oicr.pineryreports.Main;
 import ca.on.oicr.pineryreports.data.ColumnDefinition;
 import ca.on.oicr.pineryreports.data.ReportFormat;
 import ca.on.oicr.pineryreports.reports.pdf.AddHeaderFooterEvent;
+import ca.on.oicr.pineryreports.util.GeneralUtils;
 
 /**
  * A type of report that has one table containing all of the data
@@ -36,6 +60,7 @@ public abstract class TableReport implements Report {
   private static final String COMMA = ",";
   private static final String NEWLINE = "\n";
   private static final String QUOTE = "\"";
+  private static final Map<String, String> optionsUsed = new TreeMap<>();
   
   public TableReport() {
     
@@ -191,4 +216,147 @@ public abstract class TableReport implements Report {
    */
   protected abstract String[] getRow(int rowNum);
 
+  private final ObjectMapper mapper = new ObjectMapper();
+  private final HttpClient guanyinClient = HttpClientBuilder.create().build();
+
+  @Override
+  public final void registerReportWithGuanyin(String guanyinUrl) throws HttpResponseException, IOException {
+    if (guanyinUrl == null || guanyinUrl.length() == 0) return;
+    if (getReportFromGuanyin(guanyinUrl) != null) {
+      // this version of this report already exists in Guanyin, so no need to register it
+      return;
+    }
+    ObjectNode registrationInfo = getRegistration();
+    System.out.println(String.format("Registering report %s with Guanyin (%s)", getReportName(), guanyinUrl));
+    sendRegistration(guanyinUrl, registrationInfo);
+  }
+
+  /**
+   * Queries Guanyin to see if it has a report with matching information.
+   * Guanyin returns all reports with the same name, so this will only return a report if the version also matches.
+   *
+   * @return whether Guanyin has a report with matching name and version
+   * @throws IOException
+   */
+  private JsonNode getReportFromGuanyin(String guanyinUrl) throws IOException {
+    HttpGet get = new HttpGet(String.format("%s/reportdb/report?name=%s", guanyinUrl, getReportName()));
+    try {
+      HttpResponse response = guanyinClient.execute(get);
+      JsonNode body = mapper.readTree(EntityUtils.toString(response.getEntity()));
+      ArrayNode contents = (ArrayNode) body;
+      JsonNode target = null;
+      for (JsonNode report : contents) {
+        if (getVersion().equals(report.get("version").asText())) target = report;
+      }
+      return target;
+    } catch (IOException e) {
+      System.out.println(String.format("Error querying Guanyin for report %s with version %s", getReportName(), getVersion()));
+      throw e;
+    }
+  }
+
+  private ObjectNode getRegistration() {
+    ObjectNode registration = mapper.createObjectNode();
+    registration.put("category", this.getCategory());
+    registration.put("name", this.getReportName());
+    registration.put("version", getVersion());
+    registration.set("permitted_parameters", getPermittedParams());
+    return registration;
+  }
+
+  private ObjectNode getReportRecordJson(Integer reportId, File outputFile) throws IOException {
+    ObjectNode record = mapper.createObjectNode();
+    String rightNow = GeneralUtils.getDateTimeFormat().format(new Date());
+    BasicFileAttributes attrs = Files.readAttributes(outputFile.toPath(), BasicFileAttributes.class);
+    record.put("report_id", reportId);
+    record.put("date_generated", attrs.creationTime().toString());
+    record.put("freshest_input_date", rightNow);
+    // fake the values for files_in since we're pulling from Pinery
+    ArrayNode filesIn = mapper.createArrayNode();
+    filesIn.add(String.format("Pinery data retrieved %s", rightNow));
+    record.set("files_in", filesIn);
+    record.put("report_path", outputFile.getCanonicalPath());
+    record.set("notification_targets", mapper.createObjectNode());
+    record.put("notification_message", "");
+    ObjectNode parameters = mapper.createObjectNode();
+    getOptionsUsed().entrySet().stream().forEach(e -> {
+      parameters.put(e.getKey(), e.getValue());
+    });
+    record.set("parameters", parameters);
+    return record;
+  }
+
+  /**
+   * Registers this report with Guanyin
+   * 
+   * @throws IOException
+   * @throws ClientProtocolException
+   */
+  private void sendRegistration(String guanyinUrl, ObjectNode registration) throws IOException {
+    HttpPost post = new HttpPost(String.format("%s/reportdb/report", guanyinUrl));
+    StringEntity body = new StringEntity(mapper.writeValueAsString(registration));
+    post.setEntity(body);
+    post.setHeader("Accept", "application/json");
+    post.setHeader("Content-Type", "application/json");
+    try {
+      HttpResponse response = guanyinClient.execute(post);
+      if (201 != response.getStatusLine().getStatusCode()) {
+        throw new IllegalArgumentException(
+            String.format("Error registering report with Guanyin for %s version %s: return code is %d and response body is: %s",
+                getReportName(), getVersion(), response.getStatusLine().getStatusCode(), response.getEntity().toString()));
+      }
+    } catch (IOException e) {
+      System.out.println(String.format("Error registering report %s with Guanyin", getReportName()));
+      throw e;
+    }
+  }
+
+  private final ObjectNode getPermittedParams() {
+    ObjectNode permittedParams = mapper.createObjectNode();
+    for (Option option : getOptions()) {
+      ObjectNode param = mapper.createObjectNode();
+      param.put("required", option.isRequired());
+      param.put("type", "s"); // treat everything as strings, including dates
+      permittedParams.set(option.getLongOpt(), param);
+    }
+    return permittedParams;
+  }
+
+  private final Package mainPackage = Main.class.getPackage();
+
+  private final String getVersion() {
+    return mainPackage.getImplementationVersion();
+  }
+
+  @Override
+  public void writeGuanyinReportRecordParameters(String guanyinUrl, File outputFile) throws IOException {
+    JsonNode report = getReportFromGuanyin(guanyinUrl);
+    if (report == null) throw new IllegalArgumentException(String
+        .format("Could not find report %s with version %s in Guanyin so could not write parameters for report record", getReportName(),
+            getVersion()));
+    JsonNode reportRecord = getReportRecordJson(report.get("report_id").asInt(), outputFile);
+    
+    String outputFileDir = outputFile.getParent();
+    String outputFilePath = "";
+    if (outputFileDir != null) outputFilePath += outputFileDir + "/";
+    outputFilePath += FilenameUtils.removeExtension(outputFile.getName());
+    outputFilePath += ".guanyin.json";
+    System.out.println("Guanyin report record JSON generated: " + outputFilePath);
+    ObjectWriter writer = mapper.writer();
+    writer.writeValue(new File(outputFilePath), reportRecord);
+  }
+
+  @Override
+  public Map<String, String> getOptionsUsed() {
+    return optionsUsed;
+  }
+
+  @Override
+  public void recordOptionsUsed(CommandLine cmd) {
+    for (Option opt : getOptions()) {
+      if (cmd.hasOption(opt.getLongOpt())) {
+        optionsUsed.put(opt.getLongOpt(), cmd.getOptionValue(opt.getLongOpt()));
+      }
+    }
+  }
 }

--- a/src/main/java/ca/on/oicr/pineryreports/reports/impl/BisqueProjectsStatusReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/impl/BisqueProjectsStatusReport.java
@@ -180,6 +180,7 @@ public class BisqueProjectsStatusReport extends TableReport {
 
   private static final Option OPT_PROJECT = CommonOptions.project(false);
   public static final String REPORT_NAME = "projects-status";
+  public static final String CATEGORY = REPORT_CATEGORY_COUNTS;
 
   private List<Map.Entry<String, Map<String, List<Count>>>> countsByProjectAsList; // String project, List<Count> all counts
 
@@ -199,6 +200,12 @@ public class BisqueProjectsStatusReport extends TableReport {
       List<String> projx = Arrays.asList(cmd.getOptionValue(OPT_PROJECT.getLongOpt()).split(","));
       this.projects = projx.stream().map(String::trim).collect(Collectors.toSet());
     }
+    recordOptionsUsed(cmd);
+  }
+
+  @Override
+  public String getCategory() {
+    return CATEGORY;
   }
 
   @Override

--- a/src/main/java/ca/on/oicr/pineryreports/reports/impl/DonorReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/impl/DonorReport.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.pineryreports.reports.impl;
 
+import static ca.on.oicr.pineryreports.util.GeneralUtils.REPORT_CATEGORY_COUNTS;
 import static ca.on.oicr.pineryreports.util.SampleUtils.*;
 
 import java.text.SimpleDateFormat;
@@ -32,6 +33,7 @@ import ca.on.oicr.ws.dto.SampleDto;
 public class DonorReport extends TableReport {
   
   public static final String REPORT_NAME = "donor";
+  public static final String CATEGORY = REPORT_CATEGORY_COUNTS;
   private static final Option OPT_PROJECT = CommonOptions.project(true);
   private String project;
   
@@ -60,6 +62,12 @@ public class DonorReport extends TableReport {
   @Override
   public void processOptions(CommandLine cmd) throws ParseException {
     this.project = cmd.getOptionValue(OPT_PROJECT.getLongOpt()).trim();
+    recordOptionsUsed(cmd);
+  }
+
+  @Override
+  public String getCategory() {
+    return CATEGORY;
   }
 
   @Override

--- a/src/main/java/ca/on/oicr/pineryreports/reports/impl/DysReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/impl/DysReport.java
@@ -1,6 +1,6 @@
 package ca.on.oicr.pineryreports.reports.impl;
 
-import static ca.on.oicr.pineryreports.util.GeneralUtils.removeTime;
+import static ca.on.oicr.pineryreports.util.GeneralUtils.*;
 import static ca.on.oicr.pineryreports.util.SampleUtils.*;
 
 import java.util.ArrayList;
@@ -60,7 +60,7 @@ public class DysReport extends TableReport {
   }
   
   public static final String REPORT_NAME = "dys";
-  
+  public static final String CATEGORY = REPORT_CATEGORY_COUNTS;
   public static final String GSLE_USER = "Geospiza";
 
   private static final List<ColumnDefinition> COLUMNS = Collections.unmodifiableList(Arrays.asList(
@@ -90,13 +90,19 @@ public class DysReport extends TableReport {
   }
 
   @Override
+  public String getCategory() {
+    return CATEGORY;
+  }
+
+  @Override
   public Collection<Option> getOptions() {
     return Collections.emptySet();
   }
   
   @Override
   public void processOptions(CommandLine cmd) throws ParseException {
-	    // No options (could be expanded to report for any project, etc)
+    recordOptionsUsed(cmd);
+    // No options (could be expanded to report for any project, etc)
   }
 
   @Override

--- a/src/main/java/ca/on/oicr/pineryreports/reports/impl/GazpachoProjectStatusReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/impl/GazpachoProjectStatusReport.java
@@ -264,6 +264,7 @@ public class GazpachoProjectStatusReport extends TableReport {
   private static final Option OPT_BEFORE = CommonOptions.before(true);
   private static final Option OPT_ANALYTE = CommonOptions.analyte(false);
   public static final String REPORT_NAME = "project-status";
+  public static final String CATEGORY = REPORT_CATEGORY_COUNTS;
 
   // keep track of the base stock name for all samples/libraries/runs active this month
   Map<String, ReportItem> dnaThisMonth = Maps.newTreeMap();
@@ -285,6 +286,11 @@ public class GazpachoProjectStatusReport extends TableReport {
   @Override
   public Collection<Option> getOptions() {
     return Sets.newHashSet(OPT_PROJECT, OPT_AFTER, OPT_BEFORE, OPT_ANALYTE);
+  }
+
+  @Override
+  public String getCategory() {
+    return CATEGORY;
   }
 
   @Override
@@ -313,6 +319,7 @@ public class GazpachoProjectStatusReport extends TableReport {
     }
 
     this.project = cmd.getOptionValue(OPT_PROJECT.getLongOpt());
+    recordOptionsUsed(cmd);
   }
 
   @Override

--- a/src/main/java/ca/on/oicr/pineryreports/reports/impl/GeccoReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/impl/GeccoReport.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.pineryreports.reports.impl;
 
+import static ca.on.oicr.pineryreports.util.GeneralUtils.REPORT_CATEGORY_INVENTORY;
 import static ca.on.oicr.pineryreports.util.SampleUtils.*;
 
 import java.util.Arrays;
@@ -36,6 +37,7 @@ import ca.on.oicr.ws.dto.SampleReferenceDto;
 public class GeccoReport extends TableReport {
   
   public static final String REPORT_NAME = "gecco";
+  public static final String CATEGORY = REPORT_CATEGORY_INVENTORY;
   
   private final List<ColumnDefinition> columns = Collections.unmodifiableList(Arrays.asList(
       new ColumnDefinition("Oicr Name", 150f, TextAlignment.LEFT),
@@ -64,7 +66,13 @@ public class GeccoReport extends TableReport {
   }
 
   @Override
+  public String getCategory() {
+    return CATEGORY;
+  }
+
+  @Override
   public void processOptions(CommandLine cmd) throws ParseException {
+    recordOptionsUsed(cmd);
     // No options (could be expanded to report for any project, etc)
   }
 

--- a/src/main/java/ca/on/oicr/pineryreports/reports/impl/LanesBillingReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/impl/LanesBillingReport.java
@@ -144,6 +144,7 @@ public class LanesBillingReport extends TableReport {
   }
   
   public static final String REPORT_NAME = "lanes-billing";
+  public static final String CATEGORY = REPORT_CATEGORY_COUNTS;
   private static final Option OPT_AFTER = CommonOptions.after(false);
   private static final Option OPT_BEFORE = CommonOptions.before(false);
   private static final String DNA_LANE = "DNA";
@@ -181,6 +182,12 @@ public class LanesBillingReport extends TableReport {
       }
       this.end = before;
     }
+    recordOptionsUsed(cmd);
+  }
+
+  @Override
+  public String getCategory() {
+    return CATEGORY;
   }
 
   @Override

--- a/src/main/java/ca/on/oicr/pineryreports/reports/impl/LibrariesBillingReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/impl/LibrariesBillingReport.java
@@ -109,6 +109,7 @@ public class LibrariesBillingReport extends TableReport {
   }
 
   public static final String REPORT_NAME = "libraries-billing";
+  public static final String CATEGORY = REPORT_CATEGORY_COUNTS;
   private static final Option OPT_AFTER = CommonOptions.after(false);
   private static final Option OPT_BEFORE = CommonOptions.before(false);
 
@@ -142,6 +143,12 @@ public class LibrariesBillingReport extends TableReport {
       }
       this.end = before;
     }
+    recordOptionsUsed(cmd);
+  }
+
+  @Override
+  public String getCategory() {
+    return CATEGORY;
   }
 
   @Override
@@ -166,7 +173,7 @@ public class LibrariesBillingReport extends TableReport {
     List<SampleDto> newLibraries = allLibraries.stream().filter(byCreatedBetween(start, end)).collect(Collectors.toList());
 
     for (SampleDto lib : newLibraries) {
-      String kitName = lib.getPreparationKit().getName();
+      String kitName = (lib.getPreparationKit() == null ? "No Kit" : lib.getPreparationKit().getName());
       String project = lib.getProjectName();
 
       // update summary
@@ -191,7 +198,7 @@ public class LibrariesBillingReport extends TableReport {
   }
 
   private DetailedObject makeDetailedRow(SampleDto lib) {
-    return new DetailedObject(lib.getProjectName(), lib.getPreparationKit().getName(),
+    return new DetailedObject(lib.getProjectName(), (lib.getPreparationKit() == null ? "No Kit" : lib.getPreparationKit().getName()),
         lib.getCreatedDate(), lib.getName(), getAttribute(LIBRARY_DESIGN_CODE, lib));
   }
 
@@ -200,7 +207,7 @@ public class LibrariesBillingReport extends TableReport {
     return Arrays.asList(
         new ColumnDefinition("Study Title"),
         new ColumnDefinition("Library Kit"),
-        new ColumnDefinition(String.format("Count (%s - %s)", start, end)),
+        new ColumnDefinition(String.format("Count (%s - %s)", (start == null ? "Any Time" : start), (end == null ? "Now" : end))),
         new ColumnDefinition(""),
         new ColumnDefinition(""));
   }

--- a/src/main/java/ca/on/oicr/pineryreports/reports/impl/LibrariesSequencingReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/impl/LibrariesSequencingReport.java
@@ -1,6 +1,6 @@
 package ca.on.oicr.pineryreports.reports.impl;
 
-import static ca.on.oicr.pineryreports.util.GeneralUtils.RUN_FAILED;
+import static ca.on.oicr.pineryreports.util.GeneralUtils.*;
 import static ca.on.oicr.pineryreports.util.SampleUtils.*;
 
 import java.util.ArrayList;
@@ -78,6 +78,7 @@ public class LibrariesSequencingReport extends TableReport {
   }
   
   public static final String REPORT_NAME = "libraries-sequencing";
+  public static final String CATEGORY = REPORT_CATEGORY_INVENTORY;
   private static final Option OPT_PROJECT = CommonOptions.project(true);
 
   @Override
@@ -93,6 +94,12 @@ public class LibrariesSequencingReport extends TableReport {
   @Override
   public void processOptions(CommandLine cmd) throws ParseException {
     this.project = cmd.getOptionValue(OPT_PROJECT.getLongOpt());
+    recordOptionsUsed(cmd);
+  }
+
+  @Override
+  public String getCategory() {
+    return CATEGORY;
   }
 
   @Override

--- a/src/main/java/ca/on/oicr/pineryreports/reports/impl/LocationMissingReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/impl/LocationMissingReport.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.pineryreports.reports.impl;
 
+import static ca.on.oicr.pineryreports.util.GeneralUtils.REPORT_CATEGORY_QC;
 import static ca.on.oicr.pineryreports.util.SampleUtils.*;
 
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ import ca.on.oicr.ws.dto.SampleDto;
 public class LocationMissingReport extends TableReport {
 
   public static final String REPORT_NAME = "location-missing";
+  public static final String CATEGORY = REPORT_CATEGORY_QC;
   private List<SampleDto> locationMissing = new ArrayList<>();
 
   private static final Option OPT_AFTER = CommonOptions.after(false);
@@ -89,6 +91,12 @@ public class LocationMissingReport extends TableReport {
         }
       }
     }
+    recordOptionsUsed(cmd);
+  }
+
+  @Override
+  public String getCategory() {
+    return CATEGORY;
   }
 
   @Override

--- a/src/main/java/ca/on/oicr/pineryreports/reports/impl/OctaneCountsReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/impl/OctaneCountsReport.java
@@ -93,6 +93,7 @@ public class OctaneCountsReport extends TableReport {
   }
   
   public static final String REPORT_NAME = "octane";
+  public static final String CATEGORY = REPORT_CATEGORY_COUNTS;
   
   private static final Option OPT_AFTER = CommonOptions.after(false);
   private static final Option OPT_BEFORE = CommonOptions.before(false);
@@ -162,6 +163,12 @@ public class OctaneCountsReport extends TableReport {
     if (cmd.hasOption(OPT_SITE_PREFIX.getLongOpt())) {
       sitePrefix = cmd.getOptionValue(OPT_SITE_PREFIX.getLongOpt());
     }
+    recordOptionsUsed(cmd);
+  }
+
+  @Override
+  public String getCategory() {
+    return CATEGORY;
   }
 
   @Override

--- a/src/main/java/ca/on/oicr/pineryreports/reports/impl/PreciseReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/impl/PreciseReport.java
@@ -35,6 +35,7 @@ import ca.on.oicr.ws.dto.SampleDto;
 public class PreciseReport extends TableReport {
 
   public static final String REPORT_NAME = "precise";
+  public static final String CATEGORY = REPORT_CATEGORY_COUNTS;
   private String start;
   private String end;
 
@@ -209,6 +210,12 @@ public class PreciseReport extends TableReport {
       }
       this.end = before;
     }
+    recordOptionsUsed(cmd);
+  }
+
+  @Override
+  public String getCategory() {
+    return CATEGORY;
   }
 
   @Override

--- a/src/main/java/ca/on/oicr/pineryreports/reports/impl/ProjectSequencingReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/impl/ProjectSequencingReport.java
@@ -1,6 +1,6 @@
 package ca.on.oicr.pineryreports.reports.impl;
 
-import static ca.on.oicr.pineryreports.util.GeneralUtils.removeTime;
+import static ca.on.oicr.pineryreports.util.GeneralUtils.*;
 import static ca.on.oicr.pineryreports.util.SampleUtils.*;
 
 import java.util.ArrayList;
@@ -63,6 +63,7 @@ public class ProjectSequencingReport extends TableReport {
   }
   
   public static final String REPORT_NAME = "sequencing";
+  public static final String CATEGORY = REPORT_CATEGORY_INVENTORY;
   private static final Option OPT_PROJECT = CommonOptions.project(true);
   
   public static final String GSLE_USER = "Geospiza";
@@ -96,6 +97,12 @@ public class ProjectSequencingReport extends TableReport {
   @Override
   public void processOptions(CommandLine cmd) throws ParseException {
     this.project = cmd.getOptionValue(OPT_PROJECT.getLongOpt());
+    recordOptionsUsed(cmd);
+  }
+
+  @Override
+  public String getCategory() {
+    return CATEGORY;
   }
 
   @Override

--- a/src/main/java/ca/on/oicr/pineryreports/reports/impl/ReceiptMissingReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/impl/ReceiptMissingReport.java
@@ -48,6 +48,7 @@ public class ReceiptMissingReport extends TableReport {
   }
   
   public static final String REPORT_NAME = "receipt-missing";
+  public static final String CATEGORY = "qc";
   
   private static final List<ColumnDefinition> COLUMNS = Collections.unmodifiableList(Arrays.asList(
       new ColumnDefinition("Tissue ID"),
@@ -75,6 +76,12 @@ public class ReceiptMissingReport extends TableReport {
   @Override
   public void processOptions(CommandLine cmd) throws ParseException {
     this.project = cmd.getOptionValue(OPT_PROJECT.getLongOpt());
+    recordOptionsUsed(cmd);
+  }
+
+  @Override
+  public String getCategory() {
+    return CATEGORY;
   }
 
   @Override

--- a/src/main/java/ca/on/oicr/pineryreports/reports/impl/SlideReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/impl/SlideReport.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.pineryreports.reports.impl;
 
+import static ca.on.oicr.pineryreports.util.GeneralUtils.REPORT_CATEGORY_INVENTORY;
 import static ca.on.oicr.pineryreports.util.SampleUtils.*;
 
 import java.text.SimpleDateFormat;
@@ -28,6 +29,7 @@ import ca.on.oicr.ws.dto.SampleDto;
 public class SlideReport extends TableReport {
   
   public static final String REPORT_NAME = "slide";
+  public static final String CATEGORY = REPORT_CATEGORY_INVENTORY;
   
   private static final List<ColumnDefinition> COLUMNS = Collections.unmodifiableList(Arrays.asList(
       new ColumnDefinition("Slide ID"),
@@ -56,6 +58,12 @@ public class SlideReport extends TableReport {
   @Override
   public void processOptions(CommandLine cmd) throws ParseException {
     this.project = cmd.getOptionValue(OPT_PROJECT.getLongOpt());
+    recordOptionsUsed(cmd);
+  }
+
+  @Override
+  public String getCategory() {
+    return CATEGORY;
   }
 
   @Override

--- a/src/main/java/ca/on/oicr/pineryreports/reports/impl/StockReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/impl/StockReport.java
@@ -32,6 +32,7 @@ import ca.on.oicr.ws.dto.SampleDto;
 public class StockReport extends TableReport {
   
   public static final String REPORT_NAME = "stock";
+  public static final String CATEGORY = REPORT_CATEGORY_INVENTORY;
   
   private static final Option OPT_PROJECT = CommonOptions.project(true);
   private static final Option OPT_AFTER = CommonOptions.after(false);
@@ -61,6 +62,11 @@ public class StockReport extends TableReport {
   }
 
   @Override
+  public String getCategory() {
+    return CATEGORY;
+  }
+
+  @Override
   public Collection<Option> getOptions() {
     return Sets.newHashSet(OPT_PROJECT, OPT_AFTER, OPT_BEFORE);
   }
@@ -84,6 +90,7 @@ public class StockReport extends TableReport {
       }
       this.end = before;
     }
+    recordOptionsUsed(cmd);
   }
   
   @Override

--- a/src/main/java/ca/on/oicr/pineryreports/reports/impl/TglLibrariesRunReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/impl/TglLibrariesRunReport.java
@@ -58,6 +58,7 @@ public class TglLibrariesRunReport extends TableReport {
   }
   
   public static final String REPORT_NAME = "tgl-libraries-run";
+  public static final String CATEGORY = REPORT_CATEGORY_COUNTS;
   private static final Option OPT_AFTER = CommonOptions.after(false);
   private static final Option OPT_BEFORE = CommonOptions.before(false);
   private static final String DATE_REGEX = "\\d{4}-\\d{2}-\\d{2}";
@@ -105,6 +106,12 @@ public class TglLibrariesRunReport extends TableReport {
       }
       this.end = before;
     }
+    recordOptionsUsed(cmd);
+  }
+
+  @Override
+  public String getCategory() {
+    return CATEGORY;
   }
 
   @Override

--- a/src/main/java/ca/on/oicr/pineryreports/util/GeneralUtils.java
+++ b/src/main/java/ca/on/oicr/pineryreports/util/GeneralUtils.java
@@ -23,6 +23,7 @@ public class GeneralUtils {
   public static final String DATE_REGEX = "\\d{4}-\\d{2}-\\d{2}";
   public static final String DATE_FORMAT = "yyyy-MM-dd";
   public static final String DATETIME_FORMAT = "yyyy-MM-dd HH:mm";
+  public static final String DATETIMEZONE_FORMAT = "yyyy-MM-dd HH:mm:ssX";
 
   public static final String RUN_FAILED = "Failed";
   public static final String RUN_COMPLETED = "Completed";
@@ -73,5 +74,11 @@ public class GeneralUtils {
   public static DateFormat getDateTimeFormat() {
     return new SimpleDateFormat(DATE_FORMAT);
   }
+
+  // report categories
+  public static final String REPORT_CATEGORY_COUNTS = "counts";
+  public static final String REPORT_CATEGORY_INTEGRITY = "integrity";
+  public static final String REPORT_CATEGORY_INVENTORY = "inventory";
+  public static final String REPORT_CATEGORY_QC = "qc";
 
 }


### PR DESCRIPTION
GR-693
If a Guanyin URL is provided, when the report is run it will also:
  * register itself if Guanyin has no info for a report with that name and POM version
  * create a file named `$REPORT_NAME-guanyin.json` which contains information about what parameters were used to generate the report. This contains enough information to be POSTed directly to Guanyin's [`reportdb/record`](https://github.com/oicr-gsi/guanyin/blob/master/routes/index.js#L408) endpoint.