### PR TITLE
GR-734 Correctly count joined NovaSeq lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and as of version 1.0.0, follows semantic versioning.
 
 ## Unreleased
+### Fixed:
+  * `lanes-billing`: libraries count in NovaSeq joined lanes
 
 ## [1.3.1]  2019-04-04
-## Changed:
+### Changed:
   * `octane`: filter all samples by creator
   * `bisque`: added more library designs
 

--- a/src/main/java/ca/on/oicr/pineryreports/reports/impl/LanesBillingReport.java
+++ b/src/main/java/ca/on/oicr/pineryreports/reports/impl/LanesBillingReport.java
@@ -279,7 +279,7 @@ public class LanesBillingReport extends TableReport {
       if (NOVASEQ.equals(instrumentModel)) novaSeqLanesCount = run.getPositions().size();
       for (RunDtoPosition lane : run.getPositions()) {
         int laneNumber = lane.getPosition();
-        int samplesInLane = lane.getSamples() == null ? 0 : lane.getSamples().size();
+        int samplesInLane = 0;
         boolean dnaInLane = false;
         boolean rnaInLane = false;
         Map<String, Integer> projectsInLane = new HashMap<>();
@@ -314,6 +314,8 @@ public class LanesBillingReport extends TableReport {
             addSummaryData(summaryData, noProject);
             // skip further processing because there are no samples in the lane
             continue;
+          } else {
+            samplesInLane = lane.getSamples().size();
           }
         } else {
           // NextSeq flowcells are 4 lanes but they can't be split. We report these as single-lane


### PR DESCRIPTION
It wasn't counting the libraries in the joined (empty) NovaSeq lanes